### PR TITLE
Update health checks for additional dependencies

### DIFF
--- a/lua/astronvim/health.lua
+++ b/lua/astronvim/health.lua
@@ -48,6 +48,8 @@ function M.check()
     },
     { cmd = { "btm" }, type = "warn", msg = "Used for mappings to pull up system monitor (Optional)" },
     { cmd = { "python", "python3" }, type = "warn", msg = "Used for mappings to pull up python REPL (Optional)" },
+    { cmd = { "tree-sitter" }, type = "warn", msg = "Used for Treesitter `auto_install` feature (Optional)" },
+    { cmd = { "xclip", "xsel", "pbcopy", "wl-copy" }, type = "warn", msg = "Used for system clipboard integration (Optional)" },
   }
 
   for _, program in ipairs(programs) do


### PR DESCRIPTION
Add checks for `tree-sitter` CLI and `clipboard` tool in the health check script.

* Add a check for the presence of the `tree-sitter` CLI, used for Treesitter `auto_install` feature (Optional).
* Add a check for the presence of the `clipboard` tool (`xclip`, `xsel`, `pbcopy`, `wl-copy`), used for system clipboard integration (Optional).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ayanalamMOON/AstroNvim_config?shareId=5a717248-7588-4cb2-8609-f16a8b617153).